### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/mgattozzi/pare/releases/tag/v0.1.0) - 2024-05-30
+
+### Added
+- add LICENSE to pare
+- add release-plz to pare
+- add cargo dist and oranda
+- add clipboard daemon capabilities
+- initial commit
+
+### Fixed
+- use prepared statements to avoid crashes
+- cargo clippy and crashing on empty enter
+- don't crash daemon on empty board
+- clean up terminal on error


### PR DESCRIPTION
## 🤖 New release
* `pare`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/mgattozzi/pare/releases/tag/v0.1.0) - 2024-05-30

### Added
- add LICENSE to pare
- add release-plz to pare
- add cargo dist and oranda
- add clipboard daemon capabilities
- initial commit

### Fixed
- use prepared statements to avoid crashes
- cargo clippy and crashing on empty enter
- don't crash daemon on empty board
- clean up terminal on error
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).